### PR TITLE
Fixes #1 by temporarily removing repeat char preference algorithm

### DIFF
--- a/caddy.py
+++ b/caddy.py
@@ -69,13 +69,17 @@ class WordleCaddy(cmd.Cmd):
             self.do_contains("".join(in_word))
         self.do_suggest("")
 
-    def do_find(self, arg, sub_search=False, show=True):
+    def do_find(self, arg, sub_search=False, show=True, save=True):
         """Finds arg in the word list using regex syntax."""
         regex = re.compile(arg)
         words = self.last_search if sub_search else self.words
-        self.last_search = [word for word in words if regex.match(word)]
+        last_search = [word for word in words if regex.match(word)]
         if show:
-            print(self.last_search, len(self.last_search))
+            print(last_search, len(last_search))
+        if save:
+            self.last_search = last_search
+        else:
+            return last_search  # TODO: so cludgy!
 
     def do_sub(self, arg):
         """Executes a find within the last results."""
@@ -101,24 +105,17 @@ class WordleCaddy(cmd.Cmd):
         """Displays word suggestions."""
         suggestion = self.recommended if auto_suggest else None
         if auto_suggest:
-            # TODO: Implement unbuggy prefernce for unique characters
-            # (This is buggy because it doesn't account for the current search results)
-            # self.do_find(no_repeat_chars_regex, True, False)
-            # if self.last_search and 10 < (choices := len(self.last_search)) < 100:
-            #     # suggestion = random.choice(
-            #     #     [word for word in self.last_search if set(word) == 5]
-            #     # )
-            #     suggestion = (
-            #         random.choice(self.last_search)
-            #         if self.last_search
-            #         else self.recommended
-            #     )
-            # else:
-            suggestion = (
-                random.choice(self.last_search)
-                if self.last_search
-                else self.recommended
+            last_search = self.do_find(
+                no_repeat_chars_regex, sub_search=True, show=False, save=False
             )
+            if last_search and len(last_search) > 10:
+                suggestion = random.choice(last_search)
+            else:
+                suggestion = (
+                    random.choice(self.last_search)
+                    if self.last_search
+                    else self.recommended
+                )
 
         if suggestion and self.recommended != suggestion:
             self.recommended = suggestion

--- a/caddy.py
+++ b/caddy.py
@@ -3,19 +3,23 @@ import random
 import re
 import pathlib
 
-WORDS_FILE = 'target_words.txt'
-no_repeat_chars_regex = r'^(?:([a-z])(?!.*\1))*$'  # Ensure unique characters in suggestions
-OPENER = 'crane'
-INTRO = 'Welcome to Wordle Caddy: a Wordle word filterer.\nType help for a list of commands.'
+WORDS_FILE = "target_words.txt"
+no_repeat_chars_regex = (
+    r"^(?:([a-z])(?!.*\1))*$"  # Ensure unique characters in suggestions
+)
+OPENER = "crane"
+INTRO = "Welcome to Wordle Caddy: a Wordle word filterer.\nType help for a list of commands."
 
 
 class WordleCaddy(cmd.Cmd):
     def __init__(self):
         super().__init__()
-        self.words = (pathlib.Path(__file__).parent / WORDS_FILE).read_text().splitlines()
+        self.words = (
+            (pathlib.Path(__file__).parent / WORDS_FILE).read_text().splitlines()
+        )
         self.last_search = self.words
         self.intro = INTRO
-        self.prompt = '(wordle ) '
+        self.prompt = "(wordle ) "
         self.not_contains = set()
         self.contains = set()
         self.matches = set()
@@ -24,7 +28,7 @@ class WordleCaddy(cmd.Cmd):
     def do_ipick(self, arg):
         """Intelligently picks a word based on textual representation of clues."""
         try:
-            guess, score = re.split(r'\s|:', arg)
+            guess, score = re.split(r"\s|:", arg)
         except ValueError:
             score = arg
             guess = self.recommended
@@ -34,18 +38,18 @@ class WordleCaddy(cmd.Cmd):
             return
 
         not_in_word = []
-        exact_positions = ['.'] * len(guess)
+        exact_positions = ["."] * len(guess)
         in_word = []
-        not_in_positions = ['.'] * len(guess)
+        not_in_positions = ["."] * len(guess)
 
         for i, (g, s) in enumerate(zip(guess, score)):
-            if s in '-_.g':
+            if s in "-_.g":
                 not_in_word.append(g)
-            elif s in 'o?y':
+            elif s in "o?y":
                 in_word.append(g)
                 not_in_positions[i] = g
                 self.contains.add(g)
-            elif s in 'x+g':
+            elif s in "x+g":
                 exact_positions[i] = g
                 self.matches.add(g)
 
@@ -53,13 +57,17 @@ class WordleCaddy(cmd.Cmd):
 
     def process_filters(self, not_in_word, exact_positions, not_in_positions, in_word):
         """Applies filters based on the clues provided."""
-        if not_in_word_filtered := [char for char in not_in_word if char not in self.contains.union(self.matches)]:
-            self.do_not(''.join(not_in_word_filtered))
-        self.do_sub(''.join(exact_positions))
-        self.do_sub(''.join([f'[^{c}]' if c != '.' else '.' for c in not_in_positions]))
+        if not_in_word_filtered := [
+            char
+            for char in not_in_word
+            if char not in self.contains.union(self.matches)
+        ]:
+            self.do_not("".join(not_in_word_filtered))
+        self.do_sub("".join(exact_positions))
+        self.do_sub("".join([f"[^{c}]" if c != "." else "." for c in not_in_positions]))
         if in_word:
-            self.do_contains(''.join(in_word))
-        self.do_suggest('')
+            self.do_contains("".join(in_word))
+        self.do_suggest("")
 
     def do_find(self, arg, sub_search=False, show=True):
         """Finds arg in the word list using regex syntax."""
@@ -79,7 +87,7 @@ class WordleCaddy(cmd.Cmd):
             self.contains = set()
             return
         self.contains.update(arg)
-        query = ''.join(f'(?=.*{c})' for c in self.contains)
+        query = "".join(f"(?=.*{c})" for c in self.contains)
         self.do_sub(query)
 
     def do_suggest(self, arg, auto_suggest=True):
@@ -93,8 +101,25 @@ class WordleCaddy(cmd.Cmd):
         """Displays word suggestions."""
         suggestion = self.recommended if auto_suggest else None
         if auto_suggest:
-            self.do_find(no_repeat_chars_regex, True, False)
-            suggestion = random.choice(self.last_search) if self.last_search else self.recommended
+            # TODO: Implement unbuggy prefernce for unique characters
+            # (This is buggy because it doesn't account for the current search results)
+            # self.do_find(no_repeat_chars_regex, True, False)
+            # if self.last_search and 10 < (choices := len(self.last_search)) < 100:
+            #     # suggestion = random.choice(
+            #     #     [word for word in self.last_search if set(word) == 5]
+            #     # )
+            #     suggestion = (
+            #         random.choice(self.last_search)
+            #         if self.last_search
+            #         else self.recommended
+            #     )
+            # else:
+            suggestion = (
+                random.choice(self.last_search)
+                if self.last_search
+                else self.recommended
+            )
+
         if suggestion and self.recommended != suggestion:
             self.recommended = suggestion
             print("Suggested:", suggestion)
@@ -107,7 +132,7 @@ class WordleCaddy(cmd.Cmd):
             self.not_contains = set()
             return
         self.not_contains.update(arg)
-        self.do_sub(r'[^' + ''.join(self.not_contains) + ']{5}')
+        self.do_sub(r"[^" + "".join(self.not_contains) + "]{5}")
 
     def do_reset(self, arg):
         """Resets the search to the full word list."""
@@ -129,5 +154,5 @@ def main():
     w.cmdloop()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Addresses a critical issue with the codebase whereby the autopicker's preference for selecting words with repeated characters was conflated with narrowing the scope to only those words without repeated characters. This would mean that `ipick` would fail if the target word itself contained repeated characters.

Because the code is 🍝, this fix disables the non-repeat character selection strategy. 